### PR TITLE
Trim decoded exit code

### DIFF
--- a/core/src/main/scala/snailgun/protocol/Protocol.scala
+++ b/core/src/main/scala/snailgun/protocol/Protocol.scala
@@ -190,7 +190,7 @@ class Protocol(
         case ChunkTypes.Exit.toByteRepr =>
           val bytes = readPayload(bytesToRead, in)
           val code =
-            Integer.parseInt(new String(bytes, StandardCharsets.US_ASCII))
+            Integer.parseInt(new String(bytes, StandardCharsets.US_ASCII).trim)
           Action.Exit(code)
         case _ =>
           val error = new RuntimeException(s"Unexpected chunk type: $chunkType")


### PR DESCRIPTION
If the decoded payload has a trailing newline for whatever reason, `parseInt` will fail.

This will (likely) fix this error:

```
java.lang.NumberFormatException: For input string: "0
"
        at java.lang.Integer.parseInt(Integer.java:652)
        at java.lang.Integer.parseInt(Integer.java:770)
        at snailgun.protocol.Protocol.$anonfun$processChunkFromServer$1(Protocol.scala:193)
        at scala.util.Try$.apply(Try.scala:213)
        at snailgun.protocol.Protocol.processChunkFromServer(Protocol.scala:180)
        at snailgun.protocol.Protocol.sendCommand(Protocol.scala:108)
        at snailgun.TcpClient.run(TcpClient.scala:34)
        at bloop.bloopgun.BloopgunCli.executeCmd$1(Bloopgun.scala:268)
        at bloop.bloopgun.BloopgunCli.fireCommand(Bloopgun.scala:274)
        at bloop.bloopgun.BloopgunCli.run(Bloopgun.scala:230)
        at bloop.bloopgun.Bloopgun$.main(Bloopgun.scala:638)
        at bloop.bloopgun.Bloopgun.main(Bloopgun.scala)
```

System information:

```
bloop v1.4.1

Using Scala v2.12.8 and Zinc v1.3.0-M4+42-5daa8ed7
Running on Java JDK v14.0.1 (/Library/Java/JavaVirtualMachines/adoptopenjdk-14.jdk/Contents/Home)
```